### PR TITLE
Minor bug fix for ncdDetect.R

### DIFF
--- a/R/ncdDetect.R
+++ b/R/ncdDetect.R
@@ -21,7 +21,7 @@ ncdDetect <- function(predictions, scores, observations = NA, thres = NA) {
   # Make initial checks on input --------------------------------------------
 
   observation_available <- F
-  if (sum(as.numeric(is.na(sample_specific_predictions))) == 0) {
+  if ( ! any(is.na(observations)) ) {
     observation_available <- T
   }
   


### PR DESCRIPTION
The sample_specific_predictions variable here is presumably being supplied from the global namespace, but it seems to me that the intent of the code was to check for NA in the observations variable.